### PR TITLE
Fix gateway URL selection for native Linux vs WSL/Docker Desktop

### DIFF
--- a/neurons/miner/scripts/test_agent_lib/execution.py
+++ b/neurons/miner/scripts/test_agent_lib/execution.py
@@ -2,6 +2,8 @@ import asyncio
 import time
 import uuid
 from pathlib import Path
+import os
+import platform
 
 from bittensor_wallet import Wallet
 from rich.console import Console
@@ -13,9 +15,25 @@ from neurons.validator.utils.logger.logger import NuminousLogger
 
 console = Console()
 
+def is_wsl() -> bool:
+    return (
+        "WSL_DISTRO_NAME" in os.environ
+        or "microsoft" in platform.release().lower()
+        or "microsoft" in open("/proc/version", "r").read().lower()
+    )
 
 def get_gateway_url() -> str:
-    return "http://host.docker.internal:8000"
+    if is_wsl():
+        # WSL + Docker Desktop
+        return "http://host.docker.internal:8000/"
+    
+    system = platform.system()
+    if system == "Linux":
+        # Native Linux Docker
+        return "http://172.17.0.1:8000/"
+    
+    # Windows / macOS Docker Desktop
+    return "http://host.docker.internal:8000/"
 
 
 GATEWAY_URL = get_gateway_url()


### PR DESCRIPTION
Based on earlier feedback, get_gateway_url() was simplified to always return http://host.docker.internal:8000.

While this works for Docker Desktop on Windows/macOS and WSL, it breaks native Linux setups where host.docker.internal is not available and the correct Docker bridge gateway is typically 172.17.0.1.

This PR restores platform-aware detection:

Native Linux → http://172.17.0.1:8000

WSL (Ubuntu on Windows) → http://host.docker.internal:8000

Windows/macOS Docker Desktop → http://host.docker.internal:8000

This keeps the previous fix for WSL while avoiding regressions for Ubuntu/Linux users.

Tested on:

Ubuntu 24.04 (native)

Windows 11 + WSL Ubuntu + Docker Desktop