### PR TITLE
feat(run-agents): spread predictions throughout the day with events_per_interval

### DIFF
--- a/neurons/validator/db/operations.py
+++ b/neurons/validator/db/operations.py
@@ -668,6 +668,24 @@ class DatabaseOperations:
         )
         return result is not None
 
+    async def get_event_ids_with_predictions(
+        self, event_ids: list[str]
+    ) -> set[str]:
+        """Return the subset of event_ids that have at least one prediction."""
+        if not event_ids:
+            return set()
+
+        placeholders = ", ".join("?" for _ in event_ids)
+        rows = await self.__db_client.many(
+            f"""
+            SELECT DISTINCT unique_event_id
+            FROM predictions
+            WHERE unique_event_id IN ({placeholders})
+            """,
+            parameters=list(event_ids),
+        )
+        return {row[0] if isinstance(row, tuple) else row["unique_event_id"] for row in rows}
+
     async def get_latest_prediction_for_event_and_miner(
         self,
         unique_event_id: str,

--- a/neurons/validator/main.py
+++ b/neurons/validator/main.py
@@ -134,6 +134,7 @@ async def main():
         sync_hour=validator_sync_hour,
         validator_uid=validator_uid,
         validator_hotkey=validator_hotkey,
+        events_per_interval=config.get("run_agents", {}).get("events_per_interval", 0),
     )
 
     export_predictions_task = ExportPredictions(

--- a/neurons/validator/tasks/run_agents.py
+++ b/neurons/validator/tasks/run_agents.py
@@ -50,6 +50,7 @@ class RunAgents(AbstractTask):
         sync_hour: int = 1,
         validator_uid: int = 0,
         validator_hotkey: str = "",
+        events_per_interval: int = 0,
     ):
         if not isinstance(interval_seconds, float) or interval_seconds <= 0:
             raise ValueError("interval_seconds must be a positive number (float).")
@@ -83,6 +84,9 @@ class RunAgents(AbstractTask):
         if not isinstance(validator_hotkey, str):
             raise TypeError("validator_hotkey must be a string.")
 
+        if not isinstance(events_per_interval, int) or events_per_interval < 0:
+            raise ValueError("events_per_interval must be a non-negative integer.")
+
         self.interval = interval_seconds
         self.db_operations = db_operations
         self.sandbox_manager = sandbox_manager
@@ -93,6 +97,7 @@ class RunAgents(AbstractTask):
         self.max_concurrent_sandboxes = max_concurrent_sandboxes
         self.timeout_seconds = timeout_seconds
         self.sync_hour = sync_hour
+        self.events_per_interval = events_per_interval
         self.validator_uid = validator_uid
         self.validator_hotkey = validator_hotkey
 
@@ -147,6 +152,10 @@ class RunAgents(AbstractTask):
 
         interval_start_minutes = get_interval_start_minutes()
 
+        # Throttle new events if events_per_interval is set
+        if self.events_per_interval > 0:
+            events = await self._throttle_events(events)
+
         self.logger.info(
             "Starting to run agents",
             extra={
@@ -157,6 +166,28 @@ class RunAgents(AbstractTask):
         )
 
         await self.execute_all(events, valid_agents, interval_start_minutes)
+
+    async def _throttle_events(self, events: list) -> list:
+        """Limit new (unpredicted) events per interval while always including already-predicted ones."""
+        event_ids = [e[0] for e in events]
+        predicted_ids = await self.db_operations.get_event_ids_with_predictions(event_ids)
+
+        already_predicted = [e for e in events if e[0] in predicted_ids]
+        new_events = [e for e in events if e[0] not in predicted_ids]
+
+        budgeted_new = new_events[: self.events_per_interval]
+
+        self.logger.debug(
+            "Throttled events",
+            extra={
+                "already_predicted": len(already_predicted),
+                "new_total": len(new_events),
+                "new_budgeted": len(budgeted_new),
+                "events_per_interval": self.events_per_interval,
+            },
+        )
+
+        return already_predicted + budgeted_new
 
     def filter_agents_by_metagraph(self, agents: List[MinerAgentsModel]) -> List[MinerAgentsModel]:
         valid_agents = []

--- a/neurons/validator/tasks/tests/test_run_agents.py
+++ b/neurons/validator/tasks/tests/test_run_agents.py
@@ -2522,3 +2522,216 @@ class TestRunAgentsMaxRetries:
                 "agent_version_id": "a23e4567-e89b-12d3-a456-426614174000",
             },
         )
+
+
+class TestRunAgentsEventsPerInterval:
+    """Tests for budget-based throttling of new events per interval."""
+
+    def _make_event_tuple(self, event_id: str):
+        return (event_id, f"ext_{event_id}", "polymarket", "llm", "Title", "desc", None, "{}")
+
+    def _make_task(
+        self,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+        events_per_interval=3,
+    ):
+        return RunAgents(
+            interval_seconds=600.0,
+            db_operations=mock_db_operations,
+            sandbox_manager=mock_sandbox_manager,
+            netuid=99,
+            subtensor=mock_subtensor_cm,
+            api_client=mock_api_client,
+            logger=mock_logger,
+            events_per_interval=events_per_interval,
+        )
+
+    def test_events_per_interval_stored(
+        self,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        task = self._make_task(
+            mock_db_operations,
+            mock_sandbox_manager,
+            mock_subtensor_cm,
+            mock_api_client,
+            mock_logger,
+            events_per_interval=5,
+        )
+        assert task.events_per_interval == 5
+
+    def test_events_per_interval_default_is_zero(
+        self,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        task = RunAgents(
+            interval_seconds=600.0,
+            db_operations=mock_db_operations,
+            sandbox_manager=mock_sandbox_manager,
+            netuid=99,
+            subtensor=mock_subtensor_cm,
+            api_client=mock_api_client,
+            logger=mock_logger,
+        )
+        assert task.events_per_interval == 0
+
+    def test_events_per_interval_invalid_negative(
+        self,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        with pytest.raises(ValueError, match="events_per_interval must be a non-negative integer"):
+            RunAgents(
+                interval_seconds=600.0,
+                db_operations=mock_db_operations,
+                sandbox_manager=mock_sandbox_manager,
+                netuid=99,
+                subtensor=mock_subtensor_cm,
+                api_client=mock_api_client,
+                logger=mock_logger,
+                events_per_interval=-1,
+            )
+
+    @patch("neurons.validator.tasks.run_agents.get_interval_start_minutes", return_value=1000)
+    @patch("neurons.validator.tasks.run_agents.datetime")
+    async def test_throttles_new_events_to_budget(
+        self,
+        mock_datetime,
+        mock_get_interval,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        """With events_per_interval=2, only 2 new events should be processed."""
+        mock_datetime.now.return_value = datetime(2025, 12, 3, 10, 0, 0)
+
+        # 5 events total, none have predictions yet
+        events = [self._make_event_tuple(f"event_{i}") for i in range(5)]
+        mock_db_operations.get_events_to_predict.return_value = events
+        mock_db_operations.get_active_agents.return_value = [MagicMock(spec=MinerAgentsModel)]
+        mock_db_operations.get_event_ids_with_predictions.return_value = set()
+
+        task = self._make_task(
+            mock_db_operations,
+            mock_sandbox_manager,
+            mock_subtensor_cm,
+            mock_api_client,
+            mock_logger,
+            events_per_interval=2,
+        )
+        task.filter_agents_by_metagraph = MagicMock(
+            return_value=[MagicMock(spec=MinerAgentsModel)]
+        )
+        task.execute_all = AsyncMock()
+
+        await task.run()
+
+        # Should only pass 2 events (the budget) to execute_all
+        task.execute_all.assert_awaited_once()
+        called_events = task.execute_all.call_args[0][0]
+        assert len(called_events) == 2
+
+    @patch("neurons.validator.tasks.run_agents.get_interval_start_minutes", return_value=1000)
+    @patch("neurons.validator.tasks.run_agents.datetime")
+    async def test_already_predicted_events_always_included(
+        self,
+        mock_datetime,
+        mock_get_interval,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        """Events with existing predictions should always be included (for replication)."""
+        mock_datetime.now.return_value = datetime(2025, 12, 3, 10, 0, 0)
+
+        events = [self._make_event_tuple(f"event_{i}") for i in range(5)]
+        mock_db_operations.get_events_to_predict.return_value = events
+        mock_db_operations.get_active_agents.return_value = [MagicMock(spec=MinerAgentsModel)]
+        # event_0, event_1, event_2 already have predictions
+        mock_db_operations.get_event_ids_with_predictions.return_value = {
+            "event_0",
+            "event_1",
+            "event_2",
+        }
+
+        task = self._make_task(
+            mock_db_operations,
+            mock_sandbox_manager,
+            mock_subtensor_cm,
+            mock_api_client,
+            mock_logger,
+            events_per_interval=1,
+        )
+        task.filter_agents_by_metagraph = MagicMock(
+            return_value=[MagicMock(spec=MinerAgentsModel)]
+        )
+        task.execute_all = AsyncMock()
+
+        await task.run()
+
+        task.execute_all.assert_awaited_once()
+        called_events = task.execute_all.call_args[0][0]
+        called_event_ids = [e[0] for e in called_events]
+        # 3 already-predicted + 1 new (budget) = 4
+        assert len(called_events) == 4
+        # All already-predicted events must be included
+        assert "event_0" in called_event_ids
+        assert "event_1" in called_event_ids
+        assert "event_2" in called_event_ids
+
+    @patch("neurons.validator.tasks.run_agents.get_interval_start_minutes", return_value=1000)
+    @patch("neurons.validator.tasks.run_agents.datetime")
+    async def test_zero_budget_means_no_limit(
+        self,
+        mock_datetime,
+        mock_get_interval,
+        mock_db_operations,
+        mock_sandbox_manager,
+        mock_subtensor_cm,
+        mock_api_client,
+        mock_logger,
+    ):
+        """events_per_interval=0 means process all events (no throttling)."""
+        mock_datetime.now.return_value = datetime(2025, 12, 3, 10, 0, 0)
+
+        events = [self._make_event_tuple(f"event_{i}") for i in range(10)]
+        mock_db_operations.get_events_to_predict.return_value = events
+        mock_db_operations.get_active_agents.return_value = [MagicMock(spec=MinerAgentsModel)]
+
+        task = self._make_task(
+            mock_db_operations,
+            mock_sandbox_manager,
+            mock_subtensor_cm,
+            mock_api_client,
+            mock_logger,
+            events_per_interval=0,
+        )
+        task.filter_agents_by_metagraph = MagicMock(
+            return_value=[MagicMock(spec=MinerAgentsModel)]
+        )
+        task.execute_all = AsyncMock()
+
+        await task.run()
+
+        task.execute_all.assert_awaited_once()
+        called_events = task.execute_all.call_args[0][0]
+        assert len(called_events) == 10


### PR DESCRIPTION
## Problem

All ~100 daily events are processed in the first 10-min interval after `sync_hour`, creating a massive spike of sandbox executions followed by long idle periods.

## Solution

Add `events_per_interval` config parameter to `RunAgents` that limits how many **new** (unpredicted) events are processed per interval.

- **Already-predicted events** are always included (cheap replication, no sandbox needed)
- **New events** are capped to the budget per interval, spreading execution throughout the day
- **Default is 0** (no limit) for backward compatibility

### Example

With ~100 events/day and 132 intervals (22h window, 10-min intervals):
- `events_per_interval=2` → all events processed within ~50 intervals (~8 hours)
- `events_per_interval=1` → all events processed within ~100 intervals (~17 hours)

### Config

```yaml
run_agents:
  events_per_interval: 3  # 0 = no limit (current behavior)
```

## Changes

- `run_agents.py`: New `events_per_interval` param + `_throttle_events()` method
- `operations.py`: New `get_event_ids_with_predictions()` DB query  
- `main.py`: Wire config to `RunAgents`
- 6 new tests covering throttling, replication passthrough, and no-limit mode