### PR TITLE
Add Lightning Rod miner setup example

### DIFF
--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -407,7 +407,8 @@ def parse_prediction(text: str) -> float:
 
 ### Using Lightning Rod
 
-Models: `foresight-v3`, `military-strikes`. Optional context source: `perplexity`.
+Models: `foresight-v4`, `foresight-v3`, `military-strikes`. Optional context source: `perplexity`.
+Use `reasoning_effort` with `low` to reduce the reasoning budget; other options are `medium` and `high`.
 
 ```python
 import os
@@ -423,7 +424,7 @@ if not RUN_ID:
     raise ValueError("RUN_ID environment variable is required but not set")
 
 LIGHTNING_ROD_URL = f"{PROXY_URL}/api/gateway/lightning-rod/chat/completions"
-MODEL = "foresight-v3"  # or "military-strikes"
+MODEL = "foresight-v4"  # or "foresight-v3" / "military-strikes"
 CONTEXT_SOURCE = "perplexity"
 
 def parse_prediction(text: str) -> float:
@@ -449,6 +450,7 @@ Return only <answer>[number 0.0-1.0]</answer>."""
             "model": MODEL,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0.4,
+            "reasoning_effort": "low",
             "research": {"sources": [CONTEXT_SOURCE]},
             "run_id": RUN_ID,
         },
@@ -933,7 +935,7 @@ numi services link lightning-rod
 You'll be prompted for:
 - Your Lightning Rod API key (get from https://dashboard.lightningrod.ai/?redirect=/api)
 
-Use `foresight-v3` or `military-strikes` with optional `perplexity` research context.
+Use `foresight-v4`, `foresight-v3`, or `military-strikes` with optional `perplexity` research context.
 
 ### Vericore (Statement Verification)
 

--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -48,7 +48,7 @@ All events are currently 3 days events. The length of the immunity period is 7 d
 - OpenAI: https://platform.openai.com/api-keys (both but signal track is limited to responses/inference)
 - Desearch AI: https://desearch.ai/ (information track)
 - Perplexity: https://www.perplexity.ai/settings/api (information track)
-- Lightning Rod: https://lightningrod.ai (signal track)
+- Lightning Rod: https://dashboard.lightningrod.ai/?redirect=/api (signal track)
 - Vericore: https://vericore.ai (information track)
 - OpenRouter: https://openrouter.ai/settings/keys (information track)
 
@@ -407,7 +407,7 @@ def parse_prediction(text: str) -> float:
 
 ### Using Lightning Rod
 
-Models: `foresight-v3`, `military-strikes`. Context sources: `perplexity`, `exa`.
+Models: `foresight-v3`, `military-strikes`. Optional context sources: `perplexity`, `exa`.
 
 ```python
 import os
@@ -448,7 +448,7 @@ Return only <answer>[number 0.0-1.0]</answer>."""
         json={
             "model": MODEL,
             "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0.2,
+            "temperature": 0.4,
             "research": {"sources": [CONTEXT_SOURCE]},
             "run_id": RUN_ID,
         },
@@ -924,16 +924,16 @@ You'll be prompted for:
 
 ### Lightning Rod (Forecasting Models)
 
-Link your Lightning Rod account for forecasting models:
+Link your Lightning Rod API key for forecasting models. The sandbox gateway uses the linked key, so do not include it in agent code:
 
 ```bash
 numi services link lightning-rod
 ```
 
 You'll be prompted for:
-- Your Lightning Rod API key (get from https://lightningrod.ai)
+- Your Lightning Rod API key (get from https://dashboard.lightningrod.ai/?redirect=/api)
 
-Use `foresight-v3` or `military-strikes` with `perplexity` or `exa` research context.
+Use `foresight-v3` or `military-strikes` with optional `perplexity` or `exa` research context.
 
 ### Vericore (Statement Verification)
 

--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -449,7 +449,6 @@ Return only <answer>[number 0.0-1.0]</answer>."""
         json={
             "model": MODEL,
             "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0.4,
             "reasoning_effort": "low",
             "research": {"sources": [CONTEXT_SOURCE]},
             "run_id": RUN_ID,

--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -407,7 +407,7 @@ def parse_prediction(text: str) -> float:
 
 ### Using Lightning Rod
 
-Models: `foresight-v3`, `military-strikes`. Optional context sources: `perplexity`, `exa`.
+Models: `foresight-v3`, `military-strikes`. Optional context source: `perplexity`.
 
 ```python
 import os
@@ -424,7 +424,7 @@ if not RUN_ID:
 
 LIGHTNING_ROD_URL = f"{PROXY_URL}/api/gateway/lightning-rod/chat/completions"
 MODEL = "foresight-v3"  # or "military-strikes"
-CONTEXT_SOURCE = "perplexity"  # or "exa"
+CONTEXT_SOURCE = "perplexity"
 
 def parse_prediction(text: str) -> float:
     match = re.search(r"<answer>\s*([0-9]*\.?[0-9]+)\s*</answer>", text)
@@ -924,7 +924,7 @@ You'll be prompted for:
 
 ### Lightning Rod (Forecasting Models)
 
-Link your Lightning Rod API key for forecasting models. The sandbox gateway uses the linked key, so do not include it in agent code:
+Link your Lightning Rod API key for forecasting models:
 
 ```bash
 numi services link lightning-rod
@@ -933,7 +933,7 @@ numi services link lightning-rod
 You'll be prompted for:
 - Your Lightning Rod API key (get from https://dashboard.lightningrod.ai/?redirect=/api)
 
-Use `foresight-v3` or `military-strikes` with optional `perplexity` or `exa` research context.
+Use `foresight-v3` or `military-strikes` with optional `perplexity` research context.
 
 ### Vericore (Statement Verification)
 

--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -34,6 +34,7 @@ All events are currently 3 days events. The length of the immunity period is 7 d
 - **Desearch AI API key** (for local testing with web/Twitter search)
 - **OpenAI API key** (for local testing with GPT-5 models)
 - **Perplexity API key** (for local testing with reasoning LLMs)
+- **Lightning Rod API key** (for local testing with forecasting models)
 - **Vericore API key** (for local testing with statement verification)
 - **OpenRouter API key** (for local testing with multi-provider LLM access)
 - **Numinous Signals API key** (for local testing with scored news signals)
@@ -47,6 +48,7 @@ All events are currently 3 days events. The length of the immunity period is 7 d
 - OpenAI: https://platform.openai.com/api-keys (both but signal track is limited to responses/inference)
 - Desearch AI: https://desearch.ai/ (information track)
 - Perplexity: https://www.perplexity.ai/settings/api (information track)
+- Lightning Rod: https://lightningrod.ai (signal track)
 - Vericore: https://vericore.ai (information track)
 - OpenRouter: https://openrouter.ai/settings/keys (information track)
 
@@ -401,6 +403,64 @@ def parse_prediction(text: str) -> float:
             pred = float(line.replace("PREDICTION:", "").strip())
             return max(0.0, min(1.0, pred))
     return 0.5
+```
+
+### Using Lightning Rod
+
+Models: `foresight-v3`, `military-strikes`. Context sources: `perplexity`, `exa`.
+
+```python
+import os
+import re
+from typing import Dict, Any
+
+import httpx
+
+PROXY_URL = os.getenv("SANDBOX_PROXY_URL", "http://sandbox_proxy")
+RUN_ID = os.getenv("RUN_ID")
+
+if not RUN_ID:
+    raise ValueError("RUN_ID environment variable is required but not set")
+
+LIGHTNING_ROD_URL = f"{PROXY_URL}/api/gateway/lightning-rod/chat/completions"
+MODEL = "foresight-v3"  # or "military-strikes"
+CONTEXT_SOURCE = "perplexity"  # or "exa"
+
+def parse_prediction(text: str) -> float:
+    match = re.search(r"<answer>\s*([0-9]*\.?[0-9]+)\s*</answer>", text)
+    if not match:
+        return 0.5
+    return max(0.0, min(1.0, float(match.group(1))))
+
+def agent_main(event_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Uses Lightning Rod forecasting models."""
+
+    prompt = f"""Forecast the probability (0.0-1.0) of this event occurring:
+
+Event: {event_data['title']}
+Description: {event_data['description']}
+Deadline: {event_data['cutoff']}
+
+Return only <answer>[number 0.0-1.0]</answer>."""
+
+    response = httpx.post(
+        LIGHTNING_ROD_URL,
+        json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.2,
+            "research": {"sources": [CONTEXT_SOURCE]},
+            "run_id": RUN_ID,
+        },
+        timeout=120.0,
+    )
+    response.raise_for_status()
+
+    text = response.json()["choices"][0]["message"]["content"]
+    return {
+        "event_id": event_data["event_id"],
+        "prediction": parse_prediction(text),
+    }
 ```
 
 ### Using Vericore (Statement Verification)
@@ -862,6 +922,19 @@ You'll be prompted for:
 
 **Note:** Perplexity has no free tier. You must link your account to use Perplexity models.
 
+### Lightning Rod (Forecasting Models)
+
+Link your Lightning Rod account for forecasting models:
+
+```bash
+numi services link lightning-rod
+```
+
+You'll be prompted for:
+- Your Lightning Rod API key (get from https://lightningrod.ai)
+
+Use `foresight-v3` or `military-strikes` with `perplexity` or `exa` research context.
+
 ### Vericore (Statement Verification)
 
 Link your Vericore account for evidence-based statement verification:
@@ -952,8 +1025,9 @@ numi inspect-agent         # View/download agent code
 numi services link chutes     # Link Chutes API key
 numi services link desearch   # Link Desearch API key
 numi services link openai     # Link OpenAI API key
-numi services link perplexity # Link Perplexity API key
-numi services link vericore   # Link Vericore API key
+numi services link perplexity    # Link Perplexity API key
+numi services link lightning-rod # Link Lightning Rod API key
+numi services link vericore      # Link Vericore API key
 numi services link openrouter          # Link OpenRouter API key
 numi services link numinous-signals    # Link Numinous Signals API key
 numi services list                     # Check linked services

--- a/docs/miner-setup.md
+++ b/docs/miner-setup.md
@@ -408,7 +408,7 @@ def parse_prediction(text: str) -> float:
 ### Using Lightning Rod
 
 Models: `foresight-v4`, `foresight-v3`, `military-strikes`. Optional context source: `perplexity`.
-Use `reasoning_effort` with `low` to reduce the reasoning budget; other options are `medium` and `high`.
+Use `reasoning_effort` with `low` to reduce the reasoning budget.
 
 ```python
 import os


### PR DESCRIPTION
- Add a Lightning Rod miner example using the sandbox gateway.
- Document foresight-v3 and military-strikes model options.
- Mention optional perplexity research context.